### PR TITLE
Prepend mime type info in the return value of "fetchBase64" method for React Native clients

### DIFF
--- a/lib/__tests__/fetchBase64/index.native.test.js
+++ b/lib/__tests__/fetchBase64/index.native.test.js
@@ -25,4 +25,20 @@ describe('Fetch Blob as base64 string for React Native clients', () => {
       `an error occurred trying to parse the blob file.\nParsing error: ${errorMessage}`,
     );
   });
+
+  test('the returned string should start with the proper structure', async () => {
+    const reverMediaObject = { mimeType: 'image/jpg' };
+    const mockBase64 = 'asuperduperlongbase64string';
+
+    fetchBlob.mockReturnValueOnce(
+      Promise.resolve({
+        base64() {
+          return mockBase64;
+        },
+      }),
+    );
+
+    const result = await fetchBase64(reverMediaObject);
+    expect(result).toBe(`data:${reverMediaObject.mimeType};base64,${mockBase64}`);
+  });
 });

--- a/lib/__tests__/fetchBase64/index.test.js
+++ b/lib/__tests__/fetchBase64/index.test.js
@@ -9,10 +9,10 @@ describe('Fetch Blob as base64 string for Web clients', () => {
   });
 
   it('should call the "fetchBlob" function with the received args', async () => {
-    const args = { reverMediaObject: {} };
-    await fetchBase64(args);
+    const reverMediaObject = { id: 'imageid' };
+    await fetchBase64(reverMediaObject);
 
-    expect(fetchBlob).toHaveBeenCalledWith(args);
+    expect(fetchBlob).toHaveBeenCalledWith(reverMediaObject);
   });
 
   test('the returned string should start with the proper structure', async () => {

--- a/lib/fetchBase64/index.native.js
+++ b/lib/fetchBase64/index.native.js
@@ -6,11 +6,15 @@ export default async function fetchBase64(args) {
 
   try {
     const base64 = response?.base64?.();
-    return base64;
+    return buildFinalBase64String(args, base64);
   } catch (err) {
     throw new ReverMediaError(
       `an error occurred trying to parse the blob file.\nParsing error: ${err?.message ??
         'No details.'}`,
     );
   }
+}
+
+function buildFinalBase64String(args, base64) {
+  return `data:${args.mimeType};base64,${base64}`;
 }


### PR DESCRIPTION
## Changes
- Previously, the result of the `fetchBase64` method for React Native clients was the string returned by `rn-fetch-blob`.
This string didn't contain the MIME type information (something like `data:image/jpg;base64,`) required by the library used in our React Native app to render base64 images.