### PR TITLE
[MOB-554] Enable cache layer for mobile clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,17 @@ WIDE: {
 }
 ```
 
+### `fetchToLocalPath(reverMediaObject, options)` (Mobile only)
+
+This method works just like the `fetchBase64` method with the difference it returns the local path where the blob file was stored.
+This is useful for better performance in mobile clients as you can see in the ["Performance tips"](https://github.com/joltup/rn-fetch-blob#user-content-performance-tips) section of the `rn-fetch-blob` module.
+
+![](https://github.com/joltup/rn-fetch-blob/raw/master/img/performance_1.png)
+
+### `clearLocalCache()` (Mobile only)
+
+Deletes any cached blob in mobile clients.
+
 ### `setAzureStorageToken(newAzureStorageToken)`
 
 Allows to update the Azure Storage token to use for requests. This method is expected to be called by our apps after getting a new valid token.
@@ -154,7 +165,7 @@ reverMediaClient.setAzureStorageToken(newTokens.storageToken);
 console.log(reverMediaClient.azureStorageToken); // Prints newTokens.storageToken
 ```
 
-### `download(reverMediaObject)`
+### `download(reverMediaObject)` (Web only)
 
 Triggers a download process in Web browsers.
 

--- a/lib/ReverMediaClient.js
+++ b/lib/ReverMediaClient.js
@@ -2,6 +2,7 @@ import upload from './upload';
 import fetchBase64 from './fetchBase64';
 import download from './download';
 import clearLocalCache from './clearLocalCache';
+import fetchToLocalPath from './fetchToLocalPath';
 
 export default class ReverMedia {
   constructor(args) {
@@ -41,6 +42,16 @@ export default class ReverMedia {
   download(reverMediaObject) {
     return download({
       azureStorageToken: this.azureStorageToken,
+      organization: this.organization,
+      reverMediaObject,
+      reverToken: this.reverToken,
+    });
+  }
+
+  fetchToLocalPath(reverMediaObject, options) {
+    return fetchToLocalPath({
+      azureStorageToken: this.azureStorageToken,
+      options,
       organization: this.organization,
       reverMediaObject,
       reverToken: this.reverToken,

--- a/lib/ReverMediaClient.js
+++ b/lib/ReverMediaClient.js
@@ -1,6 +1,7 @@
 import upload from './upload';
 import fetchBase64 from './fetchBase64';
 import download from './download';
+import clearLocalCache from './clearLocalCache';
 
 export default class ReverMedia {
   constructor(args) {
@@ -44,5 +45,9 @@ export default class ReverMedia {
       reverMediaObject,
       reverToken: this.reverToken,
     });
+  }
+
+  clearLocalCache() {
+    return clearLocalCache();
   }
 }

--- a/lib/__mocks__/rn-fetch-blob.js
+++ b/lib/__mocks__/rn-fetch-blob.js
@@ -4,9 +4,13 @@ export const mockDispose = jest.fn(() => Promise.resolve());
 export const mockSession = jest.fn(() => ({
   dispose: mockDispose,
 }));
+export const mockConfig = jest.fn(() => ({
+  fetch: mockFetch,
+}));
 
 export default {
   fetch: mockFetch,
   wrap: mockWrap,
   session: mockSession,
+  config: mockConfig,
 };

--- a/lib/__mocks__/rn-fetch-blob.js
+++ b/lib/__mocks__/rn-fetch-blob.js
@@ -1,7 +1,12 @@
 export const mockFetch = jest.fn(() => Promise.resolve());
 export const mockWrap = jest.fn(str => `Wrapped(${str})`);
+export const mockDispose = jest.fn(() => Promise.resolve());
+export const mockSession = jest.fn(() => ({
+  dispose: mockDispose,
+}));
 
 export default {
   fetch: mockFetch,
   wrap: mockWrap,
+  session: mockSession,
 };

--- a/lib/__tests__/ReverMediaClient.test.js
+++ b/lib/__tests__/ReverMediaClient.test.js
@@ -2,10 +2,12 @@ import ReverMediaClient from '../ReverMediaClient';
 import upload from '../upload';
 import fetchBase64 from '../fetchBase64';
 import download from '../download';
+import clearLocalCache from '../clearLocalCache';
 
 jest.mock('../upload');
 jest.mock('../fetchBase64');
 jest.mock('../download');
+jest.mock('../clearLocalCache');
 
 const baseArgs = {
   azureStorageToken: 'azure token',
@@ -82,6 +84,14 @@ describe('Rever Media Client API', () => {
       reverMediaObject,
       reverToken: baseArgs.reverToken,
     });
+  });
+
+  it('should call the corresponding method to clear cache', () => {
+    const instance = createInstance();
+
+    instance.clearLocalCache();
+
+    expect(clearLocalCache).toHaveBeenCalled();
   });
 });
 

--- a/lib/__tests__/ReverMediaClient.test.js
+++ b/lib/__tests__/ReverMediaClient.test.js
@@ -3,11 +3,13 @@ import upload from '../upload';
 import fetchBase64 from '../fetchBase64';
 import download from '../download';
 import clearLocalCache from '../clearLocalCache';
+import fetchToLocalPath from '../fetchToLocalPath';
 
 jest.mock('../upload');
 jest.mock('../fetchBase64');
 jest.mock('../download');
 jest.mock('../clearLocalCache');
+jest.mock('../fetchToLocalPath');
 
 const baseArgs = {
   azureStorageToken: 'azure token',
@@ -92,6 +94,23 @@ describe('Rever Media Client API', () => {
     instance.clearLocalCache();
 
     expect(clearLocalCache).toHaveBeenCalled();
+  });
+
+  it('should call the "fetchToLocalPath" method with the proper args', () => {
+    const instance = createInstance();
+
+    const reverMediaObject = { url: 'myrul.com' };
+    const options = { size: 'square' };
+
+    instance.fetchToLocalPath(reverMediaObject, options);
+
+    expect(fetchToLocalPath).toHaveBeenCalledWith({
+      azureStorageToken: baseArgs.azureStorageToken,
+      options,
+      organization: baseArgs.organization,
+      reverMediaObject,
+      reverToken: baseArgs.reverToken,
+    });
   });
 });
 

--- a/lib/__tests__/clearLocalCache/index.native.js
+++ b/lib/__tests__/clearLocalCache/index.native.js
@@ -1,0 +1,10 @@
+import { mockSession, mockDispose } from 'rn-fetch-blob';
+import clearLocalCache from '../../clearLocalCache/index.native';
+
+describe('Clear local cache for React Native clients', () => {
+  it('should call the corresponding RNFetchBlob methods', async () => {
+    await clearLocalCache();
+    expect(mockSession).toHaveBeenCalled();
+    expect(mockDispose).toHaveBeenCalled();
+  });
+});

--- a/lib/__tests__/fetchBase64/index.native.test.js
+++ b/lib/__tests__/fetchBase64/index.native.test.js
@@ -4,14 +4,6 @@ import fetchBlob from '../../fetchBlob';
 jest.mock('../../fetchBlob');
 
 describe('Fetch Blob as base64 string for React Native clients', () => {
-  it('should throw an error if an invalid size is passed', async () => {
-    const args = { reverMediaObject: { id: 'imageid' }, options: { size: 'JUMBO' } };
-
-    await expect(fetchBase64(args)).rejects.toThrow(
-      `invalid size specified. Valid sizes are: SQUARE, THUMBNAIL, CARD, WIDE and can be found in the IMAGE_SIZES enum.`,
-    );
-  });
-
   it('should call the "fetchBlob" function with the received args', async () => {
     const args = { reverMediaObject: {} };
     await fetchBase64(args);

--- a/lib/__tests__/fetchBase64/index.test.js
+++ b/lib/__tests__/fetchBase64/index.test.js
@@ -8,14 +8,6 @@ describe('Fetch Blob as base64 string for Web clients', () => {
     jest.resetAllMocks();
   });
 
-  it('should throw an error if an invalid size is passed', async () => {
-    const args = { reverMediaObject: { id: 'imageid' }, options: { size: 'JUMBO' } };
-
-    await expect(fetchBase64(args)).rejects.toThrow(
-      `invalid size specified. Valid sizes are: SQUARE, THUMBNAIL, CARD, WIDE and can be found in the IMAGE_SIZES enum.`,
-    );
-  });
-
   it('should call the "fetchBlob" function with the received args', async () => {
     const args = { reverMediaObject: { id: 'imageid' }, options: { size: 'THUMBNAIL' } };
     await fetchBase64(args);

--- a/lib/__tests__/fetchBlob/azure/index.native.test.js
+++ b/lib/__tests__/fetchBlob/azure/index.native.test.js
@@ -1,4 +1,4 @@
-import { mockFetch } from 'rn-fetch-blob';
+import { mockConfig, mockFetch } from 'rn-fetch-blob';
 
 import fetchFromAzure from '../../../fetchBlob/azure/index.native';
 
@@ -6,6 +6,7 @@ const baseArgs = {
   url: 'https://rever.blob.core.windows.net/rever-useast1-devtest01/my-file.jpg',
   azureStorageToken: 'my azure token',
   mimeType: 'image/jpg',
+  fileExtension: '.jpg',
 };
 
 describe('Fetch Blob from Azure Storage for React Native clients', () => {
@@ -15,6 +16,12 @@ describe('Fetch Blob from Azure Storage for React Native clients', () => {
 
   it('should call the corresponding endpoint using RNFetchBlob', async () => {
     await fetchFromAzure(baseArgs);
+
+    const actualConfig = mockConfig.mock.calls?.[0]?.[0];
+    expect(actualConfig).toEqual({
+      fileCache: true,
+      appendExt: baseArgs.fileExtension,
+    });
 
     const actualMethod = mockFetch.mock.calls?.[0]?.[0];
     expect(actualMethod).toBe('GET');

--- a/lib/__tests__/fetchBlob/index.test.js
+++ b/lib/__tests__/fetchBlob/index.test.js
@@ -18,9 +18,12 @@ const baseArgs = {
       'can be one of "AWS_S3" or "EXTERNAL_AZURE_STORAGE_SERVICE", set it depending on what you want to test',
   },
   reverToken: 'my token',
+  options: {
+    size: 'square',
+  },
 };
 
-describe('Fetch image from Rever API', () => {
+describe.only('Fetch BLOB from Rever API', () => {
   it('should throw an error if media provider can not be determined', async () => {
     const args = {
       ...baseArgs,
@@ -90,7 +93,7 @@ describe('Fetch image from Rever API', () => {
     await fetchBlob(args);
 
     expect(fetchFromRever).toHaveBeenCalledWith({
-      url: baseArgs.reverMediaObject.url,
+      url: `${baseArgs.reverMediaObject.url}?size=${baseArgs.options.size}`,
       reverToken: baseArgs.reverToken,
       mimeType: baseArgs.reverMediaObject.mimeType,
       fileExtension: baseArgs.reverMediaObject.fileExtension,
@@ -154,7 +157,7 @@ describe('Fetch image from Rever API', () => {
     });
 
     await fetchBlob({
-      ...baseArgs,
+      ...omit(baseArgs, 'options'),
       organization: {
         ...baseArgs.organization,
         mediaProvider: 'AWS_S3',
@@ -167,5 +170,13 @@ describe('Fetch image from Rever API', () => {
       reverToken: baseArgs.reverToken,
       fileExtension: baseArgs.reverMediaObject.fileExtension,
     });
+  });
+
+  it('should throw an error if an invalid size is passed', async () => {
+    const args = { ...baseArgs, options: { size: 'jumbo' } };
+
+    await expect(fetchBlob(args)).rejects.toThrow(
+      `invalid size specified. Valid sizes can be found in the IMAGE_SIZES enum exported by this module.`,
+    );
   });
 });

--- a/lib/__tests__/fetchBlob/index.test.js
+++ b/lib/__tests__/fetchBlob/index.test.js
@@ -23,7 +23,7 @@ const baseArgs = {
   },
 };
 
-describe.only('Fetch BLOB from Rever API', () => {
+describe('Fetch BLOB from Rever API', () => {
   it('should throw an error if media provider can not be determined', async () => {
     const args = {
       ...baseArgs,

--- a/lib/__tests__/fetchBlob/index.test.js
+++ b/lib/__tests__/fetchBlob/index.test.js
@@ -11,6 +11,7 @@ const baseArgs = {
   reverMediaObject: {
     url: 'http://env-app.reverscore.com/api/v1/media/5e7524dc6d464e00110dfc74/download',
     mimeType: 'image/jpg',
+    fileExtension: '.jpg',
   },
   organization: {
     mediaProvider:
@@ -92,6 +93,7 @@ describe('Fetch image from Rever API', () => {
       url: baseArgs.reverMediaObject.url,
       reverToken: baseArgs.reverToken,
       mimeType: baseArgs.reverMediaObject.mimeType,
+      fileExtension: baseArgs.reverMediaObject.fileExtension,
     });
   });
 
@@ -110,6 +112,7 @@ describe('Fetch image from Rever API', () => {
       url: baseArgs.reverMediaObject.url,
       azureStorageToken: baseArgs.azureStorageToken,
       mimeType: baseArgs.reverMediaObject.mimeType,
+      fileExtension: baseArgs.reverMediaObject.fileExtension,
     });
   });
 
@@ -129,6 +132,7 @@ describe('Fetch image from Rever API', () => {
       url: `${baseArgs.reverMediaObject.url}?size=thumbnail`,
       mimeType: baseArgs.reverMediaObject.mimeType,
       reverToken: baseArgs.reverToken,
+      fileExtension: baseArgs.reverMediaObject.fileExtension,
     });
 
     await fetchBlob({
@@ -146,6 +150,7 @@ describe('Fetch image from Rever API', () => {
       url: baseArgs.reverMediaObject.url,
       mimeType: baseArgs.reverMediaObject.mimeType,
       azureStorageToken: baseArgs.azureStorageToken,
+      fileExtension: baseArgs.reverMediaObject.fileExtension,
     });
 
     await fetchBlob({
@@ -160,6 +165,7 @@ describe('Fetch image from Rever API', () => {
       url: baseArgs.reverMediaObject.url,
       mimeType: baseArgs.reverMediaObject.mimeType,
       reverToken: baseArgs.reverToken,
+      fileExtension: baseArgs.reverMediaObject.fileExtension,
     });
   });
 });

--- a/lib/__tests__/fetchBlob/rever/index.native.test.js
+++ b/lib/__tests__/fetchBlob/rever/index.native.test.js
@@ -1,4 +1,4 @@
-import { mockFetch } from 'rn-fetch-blob';
+import { mockConfig, mockFetch } from 'rn-fetch-blob';
 
 import fetchFromRever from '../../../fetchBlob/rever/index.native';
 
@@ -6,6 +6,7 @@ const baseArgs = {
   url: 'https://env-app.reverscore.com/api/v1/organizations/orgId/media/mediaId/download',
   reverToken: 'my token',
   mimeType: 'image/jpg',
+  fileExtension: '.jpg',
 };
 describe('Fetch Blob from Rever API for React Native clients', () => {
   afterEach(() => {
@@ -14,6 +15,9 @@ describe('Fetch Blob from Rever API for React Native clients', () => {
 
   it('should call the corresponding endpoint using RNFetchBlob', async () => {
     await fetchFromRever(baseArgs);
+
+    const actualConfig = mockConfig.mock.calls?.[0]?.[0];
+    expect(actualConfig).toEqual({ fileCache: true, appendExt: baseArgs.fileExtension });
 
     const actualMethod = mockFetch.mock.calls?.[0]?.[0];
     expect(actualMethod).toBe('GET');

--- a/lib/__tests__/fetchToLocalPath/index.js
+++ b/lib/__tests__/fetchToLocalPath/index.js
@@ -1,0 +1,9 @@
+import fetchToLocalPath from '../../fetchToLocalPath';
+
+describe('Fetch to local path in web browsers', () => {
+  it('should throw an error', async () => {
+    await expect(fetchToLocalPath()).rejects.toThrow(
+      'blob files caching is not supported for Web clients yet.',
+    );
+  });
+});

--- a/lib/__tests__/fetchToLocalPath/index.native.js
+++ b/lib/__tests__/fetchToLocalPath/index.native.js
@@ -1,0 +1,42 @@
+import fetchToLocalPath from '../../fetchToLocalPath/index.native';
+import fetchBlob from '../../fetchBlob';
+
+jest.mock('../../fetchBlob');
+
+describe('Fetch blob to local path for React Native clients', () => {
+  it('should call the fetchBlob method with the received args', async () => {
+    const args = { reverMediaObject: {} };
+
+    await fetchToLocalPath(args);
+
+    expect(fetchBlob).toHaveBeenCalledWith(args);
+  });
+
+  it('should return the same value as the "path" method of RNFetchBlob response', async () => {
+    const mockPath = '/User/folder/myPath/file';
+
+    fetchBlob.mockReturnValueOnce({
+      path() {
+        return mockPath;
+      },
+    });
+
+    const result = await fetchToLocalPath();
+
+    expect(result).toBe(mockPath);
+  });
+
+  it('should return an specific error when something happens trying to get the local path where the file was stored', async () => {
+    const errorMessage = 'the path does not exist!';
+
+    fetchBlob.mockReturnValueOnce({
+      path() {
+        throw new Error(errorMessage);
+      },
+    });
+
+    await expect(fetchToLocalPath()).rejects.toThrow(
+      `an error occurred trying to get the local path where the file was stored.\nError: ${errorMessage}`,
+    );
+  });
+});

--- a/lib/clearLocalCache/index.js
+++ b/lib/clearLocalCache/index.js
@@ -1,0 +1,5 @@
+export default function clearLocalCache() {
+  return console.log(
+    'This method is only intended to be used in mobile clients. It has no effect in web browser environments.',
+  );
+}

--- a/lib/clearLocalCache/index.js
+++ b/lib/clearLocalCache/index.js
@@ -1,5 +1,5 @@
 export default function clearLocalCache() {
-  return console.log(
+  return console.warn(
     'This method is only intended to be used in mobile clients. It has no effect in web browser environments.',
   );
 }

--- a/lib/clearLocalCache/index.native.js
+++ b/lib/clearLocalCache/index.native.js
@@ -1,0 +1,5 @@
+import RNFetchBlob from 'rn-fetch-blob';
+
+export default function clearLocalCache() {
+  return RNFetchBlob.session().dispose();
+}

--- a/lib/fetchBase64/index.js
+++ b/lib/fetchBase64/index.js
@@ -1,9 +1,7 @@
 import ReverMediaError from '../ReverMediaError';
 import fetchBlob from '../fetchBlob';
-import validateSize from './validateSize';
 
 export default async function fetchBase64(args) {
-  validateSize(args);
   const mimeType = args?.reverMediaObject?.mimeType;
   const arrayBuffer = await fetchBlob(args);
   return parseBufferToBase64(arrayBuffer, mimeType);

--- a/lib/fetchBase64/index.native.js
+++ b/lib/fetchBase64/index.native.js
@@ -1,8 +1,7 @@
 import ReverMediaError from '../ReverMediaError';
 import fetchBlob from '../fetchBlob';
-import validateSize from './validateSize';
+
 export default async function fetchBase64(args) {
-  validateSize(args);
   const response = await fetchBlob(args);
 
   try {

--- a/lib/fetchBlob/azure/index.native.js
+++ b/lib/fetchBlob/azure/index.native.js
@@ -4,11 +4,15 @@ import config from '../../config';
 import ReverMediaError from '../../ReverMediaError';
 
 export default async function fetchFromAzure(args = {}) {
-  const { url } = args;
+  const { url, fileExtension } = args;
   const headers = buildHeaders(args);
 
   try {
-    const response = await RNFetchBlob.fetch('GET', url, headers);
+    const response = await RNFetchBlob.config({ fileCache: true, appendExt: fileExtension }).fetch(
+      'GET',
+      url,
+      headers,
+    );
     return response;
   } catch (err) {
     throw new ReverMediaError(

--- a/lib/fetchBlob/index.js
+++ b/lib/fetchBlob/index.js
@@ -2,6 +2,7 @@ import config from '../config';
 import ReverMediaError from '../ReverMediaError';
 import fetchFromRever from './rever';
 import fetchFromAzure from './azure';
+import validateSize from './validateSize';
 
 export default async function fetchBlob(args = {}) {
   const { organization } = args;
@@ -17,8 +18,8 @@ export default async function fetchBlob(args = {}) {
 function validateArgs(args) {
   const { azureStorageToken, reverMediaObject, reverToken, organization } = args;
   const mediaProvider = organization?.mediaProvider;
-
   const url = reverMediaObject?.url;
+
   if (!url) {
     throw new ReverMediaError(
       'image URL could not be determined using the provided Rever Media Object.',
@@ -39,6 +40,8 @@ function validateArgs(args) {
   if (mediaProvider === config.mediaProviders.externalAzureStorage && !azureStorageToken) {
     throw new ReverMediaError('"azureStorageToken" param is required.');
   }
+
+  validateSize(args);
 }
 
 function getFetcherByOrganization(organization) {

--- a/lib/fetchBlob/index.js
+++ b/lib/fetchBlob/index.js
@@ -10,8 +10,8 @@ export default async function fetchBlob(args = {}) {
 
   const fetch = getFetcherByOrganization(organization);
 
-  const base64String = await fetch(buildFetchArgs(args));
-  return base64String;
+  const data = await fetch(buildFetchArgs(args));
+  return data;
 }
 
 function validateArgs(args) {
@@ -61,6 +61,7 @@ function buildFetchArgs(args) {
   const fetchArgs = {
     url: buildURL(args),
     mimeType: reverMediaObject?.mimeType,
+    fileExtension: reverMediaObject?.fileExtension,
   };
 
   const mediaProvider = organization?.mediaProvider;

--- a/lib/fetchBlob/rever/index.native.js
+++ b/lib/fetchBlob/rever/index.native.js
@@ -3,11 +3,15 @@ import RNFetchBlob from 'rn-fetch-blob';
 import ReverMediaError from '../../ReverMediaError';
 
 export default async function fetchFromRever(args) {
-  const { url } = args;
+  const { url, fileExtension } = args;
   const headers = buildHeaders(args);
 
   try {
-    const response = await RNFetchBlob.fetch('GET', url, headers);
+    const response = await RNFetchBlob.config({ fileCache: true, appendExt: fileExtension }).fetch(
+      'GET',
+      url,
+      headers,
+    );
     return response;
   } catch (err) {
     throw new ReverMediaError(

--- a/lib/fetchBlob/validateSize.js
+++ b/lib/fetchBlob/validateSize.js
@@ -4,13 +4,11 @@ export default function validateSize(args) {
   const size = args?.options?.size;
   if (!size) return;
 
-  const validSizes = Object.keys(config.IMAGE_SIZES);
+  const validSizes = Object.values(config.IMAGE_SIZES);
 
   if (!validSizes.includes(size)) {
     throw new ReverMediaError(
-      `invalid size specified. Valid sizes are: ${validSizes.join(
-        ', ',
-      )} and can be found in the IMAGE_SIZES enum.`,
+      'invalid size specified. Valid sizes can be found in the IMAGE_SIZES enum exported by this module.',
     );
   }
 }

--- a/lib/fetchToLocalPath/index.js
+++ b/lib/fetchToLocalPath/index.js
@@ -1,0 +1,5 @@
+import ReverMediaError from '../ReverMediaError';
+
+export default async function fetchToLocalPath() {
+  throw new ReverMediaError(`blob files caching is not supported for Web clients yet.`);
+}

--- a/lib/fetchToLocalPath/index.native.js
+++ b/lib/fetchToLocalPath/index.native.js
@@ -1,0 +1,15 @@
+import ReverMediaError from '../ReverMediaError';
+import fetchBlob from '../fetchBlob';
+
+export default async function fetchToLocalPath(args) {
+  try {
+    const response = await fetchBlob(args);
+    const path = await response?.path?.();
+    return path;
+  } catch (err) {
+    throw new ReverMediaError(
+      `an error occurred trying to get the local path where the file was stored.\nError: ${err.message ||
+        'No details'}`,
+    );
+  }
+}


### PR DESCRIPTION
### Changes
- A new `fetchToLocalPath` method was implemented and exposed to mobile clients exclusively.
- The size validation was moved to the `fetchBlob` method.
- A new `clearLocalCache` method was implemented and exposed to mobile clients exclusively.
