### PR TITLE
Reimplement download strategy for web clients. Implement "fetchToLocalPath" method for web clients.

### DIFF
--- a/lib/__tests__/download/index.test.js
+++ b/lib/__tests__/download/index.test.js
@@ -1,6 +1,8 @@
+import fileDownload from 'js-file-download';
 import download from '../../download';
 import fetchBlob from '../../fetchBlob';
 
+jest.mock('js-file-download');
 jest.mock('../../fetchBlob');
 
 describe('Download Blob file for Web clients', () => {
@@ -8,33 +10,21 @@ describe('Download Blob file for Web clients', () => {
     jest.resetAllMocks();
   });
 
-  it('should call the "fetchBlob" function, generate an HTML <a> element, click it and remove it from the DOM after the file download has been triggered', async () => {
-    const ANCHOR_HTML_ELEMENT_TAG = 'a';
-    const DEFAULT_OBJECT_URL = 'http://localhost/';
-
-    const mockBlob = new Blob();
-    const mockLinkElement = document.createElement(ANCHOR_HTML_ELEMENT_TAG);
-
-    window.URL.createObjectURL = jest.fn().mockReturnValueOnce('');
-    jest.spyOn(document, 'createElement').mockReturnValueOnce(mockLinkElement);
-    jest.spyOn(document.body, 'appendChild');
-    jest.spyOn(document.body, 'removeChild');
-    jest.spyOn(mockLinkElement, 'click');
-
-    fetchBlob.mockReturnValueOnce(mockBlob);
+  it('should call the "fetchBlob" function and delegate the download process to the "js-file-download" module', async () => {
+    const mockBuffer = 'myarraybuffer';
+    fetchBlob.mockReturnValueOnce(Promise.resolve(mockBuffer));
 
     const args = {
-      reverMediaObject: { originalFileName: 'myfilename.jpg' },
+      reverMediaObject: { originalFileName: 'myfilename.jpg', mimeType: 'image/jpg' },
     };
 
     await download(args);
 
     expect(fetchBlob).toHaveBeenCalledWith(args);
-    expect(document.createElement).toHaveBeenCalledWith(ANCHOR_HTML_ELEMENT_TAG);
-    expect(window.URL.createObjectURL).toHaveBeenCalledWith(mockBlob);
-    expect(mockLinkElement.href).toBe(DEFAULT_OBJECT_URL);
-    expect(mockLinkElement.download).toBe(args.reverMediaObject.originalFileName);
-    expect(mockLinkElement.click).toHaveBeenCalled();
-    expect(document.body.removeChild).toHaveBeenCalledWith(mockLinkElement);
+    expect(fileDownload).toHaveBeenCalledWith(
+      mockBuffer,
+      args.reverMediaObject.originalFileName,
+      args.reverMediaObject.mimeType,
+    );
   });
 });

--- a/lib/__tests__/fetchToLocalPath/index.js
+++ b/lib/__tests__/fetchToLocalPath/index.js
@@ -1,9 +1,41 @@
+import fetchBlob from '../../fetchBlob';
 import fetchToLocalPath from '../../fetchToLocalPath';
 
+jest.mock('../../fetchBlob');
+
 describe('Fetch to local path in web browsers', () => {
-  it('should throw an error', async () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  it('should create a blob file and create an object URL using browser APIs', async () => {
+    const mockBuffer = 'mybuffer';
+    const mockBlob = {};
+    const mockObjectURL = 'localurl';
+    const args = { reverMediaObject: { mimeType: 'image/jpg' } };
+
+    jest.spyOn(window, 'Blob').mockReturnValueOnce(mockBlob);
+    fetchBlob.mockReturnValueOnce(Promise.resolve(mockBuffer));
+    window.URL.createObjectURL = jest.fn().mockReturnValueOnce(mockObjectURL);
+
+    const objectURL = await fetchToLocalPath(args);
+
+    expect(objectURL).toBe(mockObjectURL);
+
+    expect(window.Blob.mock.calls[0][0]).toEqual([mockBuffer], {
+      type: args.reverMediaObject.mimeType,
+    });
+
+    expect(window.URL.createObjectURL).toHaveBeenCalledWith(mockBlob);
+  });
+
+  it('should return a specific error if any part of the process fails', async () => {
+    const errorMessage = 'Fetching failed!';
+    fetchBlob.mockReturnValueOnce(Promise.reject(new Error(errorMessage)));
+
     await expect(fetchToLocalPath()).rejects.toThrow(
-      'blob files caching is not supported for Web clients yet.',
+      `an error occurred trying to fetch the specified file to a local path.\nError: ${errorMessage}`,
     );
   });
 });

--- a/lib/download/index.js
+++ b/lib/download/index.js
@@ -1,18 +1,10 @@
+import fileDownload from 'js-file-download';
 import fetchBlob from '../fetchBlob';
 
 export default async function download(args) {
   const blob = await fetchBlob(args);
   const fileName = args?.reverMediaObject?.originalFileName;
+  const mimeType = args?.reverMediaObject?.mimeType;
 
-  triggerBrowserDownload(blob, fileName);
-}
-
-function triggerBrowserDownload(blob, fileName) {
-  const link = document.createElement('a');
-  link.href = window.URL.createObjectURL(blob);
-  link.download = fileName;
-
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
+  fileDownload(blob, fileName, mimeType);
 }

--- a/lib/fetchToLocalPath/index.js
+++ b/lib/fetchToLocalPath/index.js
@@ -1,5 +1,17 @@
 import ReverMediaError from '../ReverMediaError';
+import fetchBlob from '../fetchBlob';
 
-export default async function fetchToLocalPath() {
-  throw new ReverMediaError(`blob files caching is not supported for Web clients yet.`);
+export default async function fetchToLocalPath(args) {
+  try {
+    const arrayBuffer = await fetchBlob(args);
+    const blob = new Blob([arrayBuffer], { type: args?.reverMediaObject?.mimeType });
+    const blobURL = window.URL.createObjectURL(blob);
+
+    return blobURL;
+  } catch (err) {
+    throw new ReverMediaError(
+      `an error occurred trying to fetch the specified file to a local path.\nError: ${err.message ||
+        'No details.'}`,
+    );
+  }
 }

--- a/lib/upload/rever/buildRequestPayload.js
+++ b/lib/upload/rever/buildRequestPayload.js
@@ -1,5 +1,6 @@
 export default function buildRequestPayload(args) {
   const { file, filePath, fileType, fileName } = args;
+
   if (file) return file;
   if (!filePath) return;
 

--- a/lib/upload/rever/index.js
+++ b/lib/upload/rever/index.js
@@ -25,7 +25,8 @@ function buildFormData(args) {
   const payload = buildRequestPayload(args);
 
   if (payload instanceof Blob) {
-    formData.append(FILE_FIELD_NAME, payload, fileName);
+    // Using payload?.name we can preserve the original filename instead of the one with an UUID
+    formData.append(FILE_FIELD_NAME, payload, payload?.name ?? fileName);
   } else {
     formData.append(FILE_FIELD_NAME, payload);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6478,6 +6478,11 @@
         }
       }
     },
+    "js-file-download": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/js-file-download/-/js-file-download-0.4.11.tgz",
+      "integrity": "sha512-VHrnxlhsZC7lTs+WlQ8Tj+7LVFflll3C6ac3Y0akOT+oEgBFT5WIK2PF7wYWdHh8BfKdy8H0IpUkMWJW12jovQ=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3935,9 +3935,9 @@
           },
           "dependencies": {
             "minimist": {
-              "version": "1.2.5",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true,
               "optional": true
             }
@@ -7277,9 +7277,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@babel/polyfill": "^7.7.0",
     "axios": "^0.19.2",
     "core-js": "^3.6.4",
+    "js-file-download": "^0.4.11",
     "lodash": "^4.17.15",
     "npm-force-resolutions": "0.0.3",
     "uuidv4": "^6.0.6"


### PR DESCRIPTION
### Changes
- Now we delegate the file download responsibility to an external module.
- The `fetchToLocalPath` method was implemented for web clients, so it could be used as an alternative for the `fetchBase64` method.
- Now we try to preserve original file names when uploading in order to improve UX when a user uploads attachments.