### PR TITLE
Allow clients to send an "isPublic" flag when uploading media

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Here's an example of what you can expect to find in a `Rever Media Object`:
 }
 ```
 
-### `upload({ file, fileExtension, filePath, fileType })`
+### `upload({ file, fileExtension, filePath, fileType, isPublic })`
 
 This method allows to upload a file, either by passing a BLOB object or only specifying the file's path in a mobile device. It returns a `Rever Media Object`.
 
@@ -172,7 +172,7 @@ WIDE: {
 }
 ```
 
-### `fetchToLocalPath(reverMediaObject, options)` (Mobile only)
+### `fetchToLocalPath(reverMediaObject, options)`
 
 This method works just like the `fetchBase64` method with the difference it returns the local path where the blob file was stored.
 This is useful for better performance in mobile clients as you can see in the ["Performance tips"](https://github.com/joltup/rn-fetch-blob#user-content-performance-tips) section of the `rn-fetch-blob` module.

--- a/lib/ReverMediaClient.js
+++ b/lib/ReverMediaClient.js
@@ -11,13 +11,14 @@ export default class ReverMedia {
     this.reverURL = args.reverURL;
   }
 
-  upload({ file, fileExtension, filePath, fileType }) {
+  upload({ file, fileExtension, filePath, fileType, isPublic }) {
     return upload({
       azureStorageToken: this.azureStorageToken,
       file,
       fileExtension,
       filePath,
       fileType,
+      isPublic: Boolean(isPublic),
       organization: this.organization,
       reverToken: this.reverToken,
       reverURL: this.reverURL,

--- a/lib/__tests__/ReverMediaClient.test.js
+++ b/lib/__tests__/ReverMediaClient.test.js
@@ -33,6 +33,7 @@ describe('Rever Media Client API', () => {
       fileExtension: 'jpg',
       filePath: 'my/Path',
       fileType: 'image/jpg',
+      isPublic: true,
     };
 
     instance.upload(args);

--- a/lib/__tests__/upload/azure/index.test.js
+++ b/lib/__tests__/upload/azure/index.test.js
@@ -45,7 +45,7 @@ describe('Upload to Azure Storage', () => {
     uploadForWeb.mockReturnValueOnce(Promise.resolve());
     axios.post.mockReturnValueOnce(Promise.resolve({ data: {} }));
 
-    await uploadToAzure(baseArgs);
+    await uploadToAzure({ ...baseArgs, isPublic: true });
 
     const actualEndpoint = axios.post.mock.calls?.[0]?.[0];
     const expectedEndpoint = `${baseArgs.reverURL}/organizations/${baseArgs.organizationId}/media`;
@@ -61,6 +61,7 @@ describe('Upload to Azure Storage', () => {
       originalFileName: baseArgs.fileName,
       fileExtension: '.jpg',
       bytes: 0,
+      isPublic: true,
     };
     expect(actualData).toEqual(expectedData);
 

--- a/lib/__tests__/upload/index.test.js
+++ b/lib/__tests__/upload/index.test.js
@@ -35,7 +35,7 @@ describe('Upload image', () => {
     await expect(upload(args)).rejects.toThrow('"reverToken" param is required');
   });
 
-  it('should throw an error if  Rever API URL is not specified', async () => {
+  it('should throw an error if Rever API URL is not specified', async () => {
     const args = omit(baseArgs, 'reverURL');
     await expect(upload(args)).rejects.toThrow('"reverURL" param is required');
   });
@@ -92,6 +92,7 @@ describe('Upload image', () => {
       fileName: 'my-image.jpg',
       filePath: baseArgs.filePath,
       fileType: baseArgs.fileType,
+      isPublic: false,
       organizationId: baseArgs.organization._id,
       reverToken: baseArgs.reverToken,
       reverURL: baseArgs.reverURL,
@@ -118,6 +119,7 @@ describe('Upload image', () => {
       fileName: `${mockUUID}.${baseArgs.fileExtension}`,
       filePath: baseArgs.filePath,
       fileType: baseArgs.fileType,
+      isPublic: false,
       organizationId: baseArgs.organization._id,
       reverToken: baseArgs.reverToken,
       reverURL: baseArgs.reverURL,

--- a/lib/__tests__/upload/rever/buildRequestPayload.test.js
+++ b/lib/__tests__/upload/rever/buildRequestPayload.test.js
@@ -1,16 +1,18 @@
 import getReverRequestPayload from '../../../upload/rever/buildRequestPayload';
 
 describe('Build Rever upload request payload', () => {
-  it('should return the "file" arg if it\'s received', () => {
+  it('should return the "file" arg if it\'s received including the "isPublic" flag', () => {
     const args = {
-      file: 'blob file',
+      file: {},
       filePath: 'path path',
       fileType: 'file type',
+      isPublic: true,
     };
 
-    const result = getReverRequestPayload(args);
+    const payload = getReverRequestPayload(args);
 
-    expect(result).toBe(args.file);
+    expect(payload).toBe(args.file);
+    expect(payload.isPublic).toBe(args.isPublic);
   });
 
   it('should return an object with the "name", "type" and "uri" keys in which "name" should be properly computed from the received "filePath" arg', () => {
@@ -20,12 +22,13 @@ describe('Build Rever upload request payload', () => {
       fileName: 'my-file.jpg',
     };
 
-    const result = getReverRequestPayload(args);
+    const payload = getReverRequestPayload(args);
 
-    expect(result).toEqual({
+    expect(payload).toEqual({
       name: args.fileName,
       type: args.fileType,
       uri: args.filePath,
+      isPublic: false,
     });
   });
 });

--- a/lib/upload/azure/createReverMediaObject.js
+++ b/lib/upload/azure/createReverMediaObject.js
@@ -33,6 +33,7 @@ function buildData(args) {
     originalFileName: args?.file?.name ?? args?.fileName,
     fileExtension: getFileExtension(args),
     bytes: args?.file?.size ?? 0,
+    isPublic: Boolean(args?.isPublic),
   };
 }
 

--- a/lib/upload/index.js
+++ b/lib/upload/index.js
@@ -69,6 +69,7 @@ function buildUploaderArgs(args) {
     file: args?.file,
     fileName: buildFileName(args),
     fileType: args?.fileType,
+    isPublic: Boolean(args?.isPublic),
     organizationId: args?.organization?._id,
     reverToken: args?.reverToken,
     reverURL: args?.reverURL,

--- a/lib/upload/rever/buildRequestPayload.js
+++ b/lib/upload/rever/buildRequestPayload.js
@@ -1,10 +1,15 @@
 export default function buildRequestPayload(args) {
-  const { file, filePath, fileType, fileName } = args;
+  const { file, filePath, fileType, fileName, isPublic } = args;
 
-  if (file) return file;
+  if (file) {
+    file.isPublic = Boolean(isPublic);
+    return file;
+  }
+
   if (!filePath) return;
 
   return {
+    isPublic: Boolean(isPublic),
     name: fileName,
     type: fileType,
     uri: filePath,


### PR DESCRIPTION
The `isPublic` flag is now accepted for the `upload` method.